### PR TITLE
Restore gmsh on all platforms

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,17 +31,9 @@ requirements:
     - petsc4py    # [unix]
     - pytrilinos  # [unix and py2k]
     - mayavi      # [not (win and py2k)]
-  # fipy still doesn't support gmsh 4.0, an optional package
-  # But gmsh 3 hasn't been built in a long time.
-  # So we leave it as an optional dependency should the users want
-  # to isntall it.
-  # As it is old, it might have some strange pinnings.
-  run_constrained:
-    - gmsh <4.0   # [not (win and py2k)]
+    - gmsh
 
 test:
-  requires:
-    - gmsh        # [not (win and py2k)]
   imports:
     - fipy
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 702f1dffc5799e47d879383bbf66bf4f1baa92e40e6241dc9e59845b6ff4df2c
 
 build:
-  number: 2
+  number: 3
   script:
     - "{{ PYTHON }} -m pip install . --no-deps -vv"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - petsc4py    # [unix]
     - pytrilinos  # [unix and py2k]
     - mayavi      # [not (win and py2k)]
-    - gmsh
+    - gmsh        # [not (win and py2k)]
 
 test:
   imports:


### PR DESCRIPTION
Thanks to usnistgov/fipy#644, newer versions of Gmsh should be fine

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
