### PR TITLE
Restore run_constrained option

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 71468d21563d7dbee0bb14ecc3944497ace5ba0b61084199bedd40fe0d80fd2e
 
 build:
-  number: 0
+  number: 1
   script:
     - "{{ PYTHON }} -m pip install . --no-deps -vv"
 
@@ -31,6 +31,12 @@ requirements:
     - petsc4py    # [unix]
     - pytrilinos  # [unix and py2k]
     - mayavi      # [not (win and py2k)]
+  # fipy still doesn't support gmsh 4.0, an optional package
+  # But gmsh 3 hasn't been built in a long time.
+  # So we leave it as an optional dependency should the users want
+  # to isntall it.
+  # As it is old, it might have some strange pinnings.
+  run_constrained:
     - gmsh <4.0   # [not (win and py2k)]
 
 test:


### PR DESCRIPTION
Hopefully help with conda's Byzantine depedency solutions

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
