### PR TITLE
Install packaging package

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,16 +165,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `fipy` can be installed with:
+Once the `conda-forge` channel has been enabled, `fipy` can be installed with `conda`:
 
 ```
 conda install fipy
 ```
 
-It is possible to list all of the versions of `fipy` available on your platform with:
+or with `mamba`:
+
+```
+mamba install fipy
+```
+
+It is possible to list all of the versions of `fipy` available on your platform with `conda`:
 
 ```
 conda search fipy --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search fipy --channel conda-forge
+```
+
+Alternatively, `mamba repoquery` may provide more information:
+
+```
+# Search all versions available on your platform:
+mamba repoquery search fipy --channel conda-forge
+
+# List packages depending on `fipy`:
+mamba repoquery whoneeds fipy --channel conda-forge
+
+# List dependencies of `fipy`:
+mamba repoquery depends fipy --channel conda-forge
 ```
 
 
@@ -192,10 +217,12 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
-packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Azure](https://azure.microsoft.com/en-us/services/devops/), [GitHub](https://github.com/),
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
+[Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
+it is possible to build and upload installable packages to the
+[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: be8caaafe3ef2dc2c5ca02d8e91472bbdde0b19df1104170915fbb0b867c17a0
 
 build:
-  number: 3
+  number: 4
   script:
     - {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -25,6 +25,7 @@ requirements:
     - scipy
     - matplotlib-base
     - future
+    - packaging
     - mpich       # [unix]
     - mpi4py      # [unix]
     - pysparse    # [py2k]


### PR DESCRIPTION
`distutils.version.StrictVersion` is deprecated in favor of `packaging.version.Version`.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
