### PR TITLE
Constrain petsc4py version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: bda9338577b9f980cced4d27f638b6830c45f93c71e058413cd5352281a28523
 
 build:
-  number: 0
+  number: 1
   script:
     - {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -29,7 +29,7 @@ requirements:
     - mpich       # [unix]
     - mpi4py      # [unix]
     - pysparse    # [py2k]
-    - petsc4py    # [unix]
+    - petsc4py < 3.21   # [unix]
     - pytrilinos  # [unix and py2k]
     - mayavi      # [not (win and py2k)]
   # fipy still doesn't take full advantage of gmsh 4.0, an optional package

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - mpich       # [unix]
     - mpi4py      # [unix]
     - pysparse    # [py2k]
-    - petsc4py < 3.21   # [unix]
+    - petsc4py <3.21   # [unix]
     - pytrilinos  # [unix and py2k]
     - mayavi      # [not (win and py2k)]
   # fipy still doesn't take full advantage of gmsh 4.0, an optional package


### PR DESCRIPTION
PETSc 3.21.2 seg faults with stuff like
```
Abort(-99) on node 1 (rank 1 in comm 0): application called MPI_Abort(MPI_COMM_WORLD, -99) - process 1
 Internal error 1 in DMUMPS_LOAD_PROCESS_MESSAGE
 Internal error 1 in DMUMPS_LOAD_RECV_MSGS           1
```

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
